### PR TITLE
Alternate way of viewing wikipedia

### DIFF
--- a/frontend/src/hooks/useWikiArticles.ts
+++ b/frontend/src/hooks/useWikiArticles.ts
@@ -1,16 +1,6 @@
 import { useState, useCallback } from "react";
 import { useLocalization } from "./useLocalization";
-
-interface WikiArticle {
-  title: string;
-  extract: string;
-  pageid: number;
-  thumbnail?: {
-    source: string;
-    width: number;
-    height: number;
-  };
-}
+import type { WikiArticle } from "../components/WikiCard";
 
 const preloadImage = (src: string): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -38,11 +28,12 @@ export function useWikiArticles() {
             format: "json",
             generator: "random",
             grnnamespace: "0",
-            prop: "extracts|pageimages",
+            prop: "extracts|pageimages|info",
+            inprop: "url",
             grnlimit: "20",
             exintro: "1",
-            exchars: "1000",
             exlimit: "max",
+            exsentences: "5",
             explaintext: "1",
             piprop: "thumbnail",
             pithumbsize: "400",
@@ -52,13 +43,17 @@ export function useWikiArticles() {
 
       const data = await response.json();
       const newArticles = Object.values(data.query.pages)
-        .map((page: any) => ({
+        .map((page: any): WikiArticle  => ({
           title: page.title,
           extract: page.extract,
           pageid: page.pageid,
           thumbnail: page.thumbnail,
+          url: page.canonicalurl,
         }))
-        .filter((article) => article.thumbnail);
+        .filter((article) => article.thumbnail
+                             && article.thumbnail.source
+                             && article.url
+                             && article.extract);
 
       await Promise.allSettled(
         newArticles

--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -132,4 +132,11 @@ export const LANGUAGES = [
     api: "https://pl.wikipedia.org/w/api.php?",
     article: "https://pl.wikipedia.org/wiki/",
   },
+  {
+    id: "nl",
+    name: "Nederlands",
+    flag: "https://hatscripts.github.io/circle-flags/flags/nl.svg",
+    api: "https://nl.wikipedia.org/w/api.php?",
+    article: "https://nl.wikipedia.org/wiki/",
+  },
 ];


### PR DESCRIPTION
Alternative way of showing pages. Autoscroll through wikipedia with V^ chevrons allowing for in-website viewing of page instead of having to go to a different page. It should work so clicking on a link keeps user inside of viewer.


![Screenshot 2025-02-05 163452](https://github.com/user-attachments/assets/2de2e98a-8279-4689-84a9-61b74895d7d9)
